### PR TITLE
Change dependency versions of sprintf and validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     }
   ],
   "dependencies": {
-    "sprintf": "latest",
-    "validator": "latest",
+    "sprintf": "0.1.5",
+    "validator": "3.40.0",
     "heap": "latest",
     "read": "latest"
   }


### PR DESCRIPTION
Interrogator is used in the program cup, and having the sprintf and validator dependencies be latest is messing with cup and giving the user unmet dependencies.