### PR TITLE
They updated validator over the weekend

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "sprintf": "0.1.5",
-    "validator": "3.40.0",
+    "validator": "3.40.1",
     "heap": "latest",
     "read": "latest"
   }


### PR DESCRIPTION
Sorry to keep making changes, but apparently validator was updated over the weekend and now having version 3.40.0 be the version gives unmet dependency warnings as well